### PR TITLE
Refactor tuple tests

### DIFF
--- a/jtuples/src/test/java/org/jtuples/PairTest.java
+++ b/jtuples/src/test/java/org/jtuples/PairTest.java
@@ -24,148 +24,136 @@ package org.jtuples;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Before;
 
 /**
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class PairTest {
+    private Pair<String, String> pair;
+    private Pair<String, String> expected;
+    private Pair<String, String> result;
+    
+    @Before
+    public void setup() {
+        pair = new Pair<>("1", "2");
+    }
 
     @Test
     public void testArity() {
-        Pair<String, String> pair = new Pair<>();
-        
-        assertEquals(pair.arity(), 2);
+        assertEquals(2, pair.arity());
     }
 
     @Test
     public void testFirst() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-
-        assertEquals(pair.first(), "hello");
+        assertEquals("1", pair.first());
     }
 
     @Test
     public void testFirstCanBeNull() {
-        Pair<Object, Object> pair = new Pair<>(null, null);
-
-        assertNull(pair.first());
+        assertNull(nullPair().first());
     }
 
     @Test
     public void testSecond() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-
-        assertEquals(pair.second(), "world");
+        assertEquals("2", pair.second());
     }
 
     @Test
     public void testSecondCanBeNull() {
-        Pair<Object, Object> pair = new Pair<>(null, null);
-
-        assertNull(pair.second());
+        assertNull(nullPair().second());
     }
 
     @Test
     public void testInvert() {
-        Pair<String, Integer> pair = new Pair<>("hello", 123);
+        expected = new Pair<>("2", "1");
 
-        Pair<Integer, String> other = pair.invert();
-
-        assertEquals((int)other.first(), 123);
-        assertEquals(other.second(), "hello");
+        assertEquals(expected, pair.invert());
     }
 
     @Test
     public void testApplyFirst() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
+        result = pair.applyFirst(s -> s + s);
 
-        Pair<Integer, String> other = pair.applyFirst(s -> s.length());
-
-        assertEquals((int)other.first(), "hello".length());
+        assertEquals("11", result.first());
     }
 
     @Test
     public void testApplySecond() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
+        result = pair.applySecond(s -> s + s);
 
-        Pair<String, Integer> other = pair.applySecond(s -> s.length());
-
-        assertEquals((int)other.second(), "world".length());
+        assertEquals("22", result.second());
     }
 
     @Test
     public void testEqualsIsTrueWhenEqual() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, String> other = new Pair<>("hello", "world");
+        Tuple other = new Pair<>("1", "2");
 
         assertTrue(pair.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenNotEqual() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, String> other = new Pair<>("goodbye", "world");
+        Tuple other = new Pair<>("2", "1");
 
         assertFalse(pair.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenTypesAreDifferent() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, Integer> other = new Pair<>("hello", 123);
+        Tuple other = new Pair<>("1", 123);
 
         assertFalse(pair.equals(other));
     }
 
     @Test
-    public void testHashCodeIsTheSameForEqualPairs() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, String> other = new Pair<>("hello", "world");
+    public void testHashCodeIsTheSameForEqualTuples() {
+       Tuple other = new Pair<>("1", "2");
 
-        assertEquals(pair.hashCode(), other.hashCode());
+        assertEquals(other.hashCode(), pair.hashCode());
     }
 
     @Test
     public void testApply() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-
-        assertTrue(pair.apply((a, b) -> {
-            return "hello".equals(a) && "world".equals(b) ?
-                    Boolean.TRUE : Boolean.FALSE;
-        }));
-    }
-
-    @Test
-    public void testShiftLeftReturnsNew() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, String> other = pair.shiftLeft();
-
-        assertNotEquals(pair, other);
+        boolean result = pair.apply((a, b) -> {
+            return "1".equals(a) && "2".equals(b);
+        });
+        
+        assertTrue(result);
     }
 
     @Test
     public void testShiftLeft() {
-        Pair<String, String> pair = new Pair<>("1", "2");
-        pair = pair.shiftLeft();
-        Pair<String, String> expected = new Pair<>("2", "1");
+        expected = new Pair<>("2", "1");
 
-        assertEquals(pair, expected);
+        assertEquals(expected, pair.shiftLeft());
     }
 
     @Test
-    public void testShiftRightReturnsNew() {
-        Pair<String, String> pair = new Pair<>("hello", "world");
-        Pair<String, String> other = pair.shiftRight();
-
-        assertNotEquals(pair, other);
+    public void testShiftLeftReturnsNew() {
+        assertNotEquals(pair, pair.shiftLeft());
     }
 
     @Test
     public void testShiftRight() {
-        Pair<String, String> pair = new Pair<>("1", "2");
-        pair = pair.shiftRight();
-        Pair<String, String> expected = new Pair<>("2", "1");
+        expected = new Pair<>("2", "1");
 
-        assertEquals(pair, expected);
+        assertEquals(expected, pair.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightReturnsNew() {
+        assertNotEquals(pair, pair.shiftRight());
+    }
+    
+    @Test
+    public void testToArray() {
+        String[] expectedArray = new String[] { "1", "2" };
+        
+        assertArrayEquals(expectedArray, pair.toArray());
+    }
+    
+    private Pair<Object, Object> nullPair() {
+        return new Pair<>();
     }
 }

--- a/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
@@ -24,218 +24,161 @@ package org.jtuples;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Before;
 
 /**
- *
- * @author Benjamim Sonntag
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class QuadrupleTest {
+    private Quadruple<String, String, String, String> quadruple;
+    private Quadruple<String, String, String, String> expected;
+    private Quadruple<String, String, String, String> result;
+    
+    @Before
+    public void setup() {
+        quadruple = new Quadruple<>("1", "2", "3", "4");
+    }
 
     @Test
     public void testArity() {
-        Quadruple<String, String, String, String> quadruple = new Quadruple<>();
-        
-        assertEquals(quadruple.arity(), 4);
+        assertEquals(4, quadruple.arity());
     }
 
     @Test
     public void testFirst() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-
-        assertEquals(quadruple.first(), "a");
+        assertEquals("1", quadruple.first());
     }
 
     @Test
     public void testFirstCanBeNull() {
-        Quadruple<Object, Object, Object, Object> quadruple =
-                new Quadruple<>(null, null, null, null);
-
-        assertNull(quadruple.first());
+        assertNull(nullQuadruple().first());
     }
 
     @Test
     public void testSecond() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-
-        assertEquals(quadruple.second(), "b");
+        assertEquals("2", quadruple.second());
     }
 
     @Test
     public void testSecondCanBeNull() {
-        Quadruple<Object, Object, Object, Object> quadruple =
-                new Quadruple<>(null, null, null, null);
-
-        assertNull(quadruple.second());
+        assertNull(nullQuadruple().second());
     }
 
     @Test
     public void testThird() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-
-        assertEquals(quadruple.third(), "c");
+        assertEquals("3", quadruple.third());
     }
 
     @Test
     public void testThirdCanBeNull() {
-        Quadruple<Object, Object, Object, Object> quadruple =
-                new Quadruple<>(null, null, null, null);
-
-        assertNull(quadruple.third());
+        assertNull(nullQuadruple().third());
     }
 
     @Test
-    public void testForth() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-
-        assertEquals(quadruple.fourth(), "d");
+    public void testFourth() {
+        assertEquals("4", quadruple.fourth());
     }
 
     @Test
-    public void testForthCanBeNull() {
-        Quadruple<Object, Object, Object, Object> quadruple =
-                new Quadruple<>(null, null, null, null);
-
-        assertNull(quadruple.fourth());
+    public void testFourthCanBeNull() {
+        assertNull(nullQuadruple().fourth());
     }
 
     @Test
     public void testInvert() {
-        Quadruple<String, String, String, Integer> quadruple =
-                new Quadruple<>("a", "b", "c", 123);
+        expected = new Quadruple<>("4", "3", "2", "1");
 
-        Quadruple<Integer, String, String, String> other = quadruple.invert();
-
-        assertEquals((int)other.first(), 123);
-        assertEquals(other.second(), "c");
-        assertEquals(other.third(), "b");
-        assertEquals(other.fourth(), "a");
+        assertEquals(expected, quadruple.invert());
     }
 
     @Test
     public void testApplyFirst() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
+        result = quadruple.applyFirst(s -> s + s);
 
-        Quadruple<String, String, String, String> other =
-                quadruple.applyFirst(s -> s + s);
-
-        assertEquals(other.first(), "aa");
+        assertEquals("11", result.first());
     }
 
     @Test
     public void testApplySecond() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
+        result = quadruple.applySecond(s -> s + s);
 
-        Quadruple<String, String, String, String> other =
-                quadruple.applySecond(s -> s + s);
-
-        assertEquals(other.second(), "bb");
+        assertEquals("22", result.second());
     }
 
     @Test
     public void testApplyThird() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
+        result = quadruple.applyThird(s -> s + s);
 
-        Quadruple<String, String, String, String> other =
-                quadruple.applyThird(s -> s + s);
-
-        assertEquals(other.third(), "cc");
+        assertEquals("33", result.third());
     }
 
     @Test
-    public void testApplyForth() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
+    public void testApplyFourth() {
+        result = quadruple.applyFourth(s -> s + s);
 
-        Quadruple<String, String, String, String> other =
-                quadruple.applyFourth(s -> s + s);
-
-        assertEquals(other.fourth(), "dd");
+        assertEquals("44", result.fourth());
     }
 
     @Test
     public void testEqualsIsTrueWhenEqual() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-        Quadruple<String, String, String, String> other =
-                new Quadruple<>("a", "b", "c", "d");
+        Tuple other = new Quadruple<>("1", "2", "3", "4");
 
         assertTrue(quadruple.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenNotEqual() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-        Quadruple<String, String, String, String> other =
-                new Quadruple<>("b", "a", "c", "d");
+        Tuple other = new Quadruple<>("2", "1", "3", "4");
 
         assertFalse(quadruple.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenTypesAreDifferent() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-        Quadruple<String, String, String, Integer> other =
-                new Quadruple<>("b", "a", "c", 123);
+        Tuple other = new Quadruple<>("1", "2", "3", 123);
 
         assertFalse(quadruple.equals(other));
     }
 
     @Test
-    public void testHashCodeIsTheSameForEqualPairs() {
-        Quadruple<String, String, String, String> quadruple =
-                new Quadruple<>("a", "b", "c", "d");
-        Quadruple<String, String, String, String> other =
-                new Quadruple<>("a", "b", "c", "d");
+    public void testHashCodeIsTheSameForEqualTuples() {
+        Tuple other = new Quadruple<>("1", "2", "3", "4");
 
-        assertEquals(quadruple.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void testShiftLeftReturnsNew() {
-        Quadruple<String, String, String, String> quad =
-                new Quadruple<>("hello", ",", "world", "!");
-        Quadruple<String, String, String, String> other = quad.shiftLeft();
-
-        assertNotEquals(quad, other);
+        assertEquals(other.hashCode(), quadruple.hashCode());
     }
 
     @Test
     public void testShiftLeft() {
-        Quadruple<String, String, String, String> quad =
-                new Quadruple<>("1", "2", "3", "4");
-        quad = quad.shiftLeft();
-        Quadruple<String, String, String, String> expected =
-                new Quadruple<>("2", "3", "4", "1");
+        expected = new Quadruple<>("2", "3", "4", "1");
 
-        assertEquals(quad, expected);
+        assertEquals(expected, quadruple.shiftLeft());
     }
 
     @Test
-    public void testShiftRightReturnsNew() {
-        Quadruple<String, String, String, String> quad =
-                new Quadruple<>("hello", ",", "world", "!");
-        Quadruple<String, String, String, String> other = quad.shiftRight();
-
-        assertNotEquals(quad, other);
+    public void testShiftLeftReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftLeft());
     }
 
     @Test
     public void testShiftRight() {
-        Quadruple<String, String, String, String> quad =
-                new Quadruple<>("1", "2", "3", "4");
-        quad = quad.shiftRight();
-        Quadruple<String, String, String, String> expected =
-                new Quadruple<>("4", "1", "2", "3");
+        expected = new Quadruple<>("4", "1", "2", "3");
 
-        assertEquals(quad, expected);
+        assertEquals(expected, quadruple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftRight());
+    }
+    
+    @Test
+    public void testToArray() {
+        String[] expectedArray = new String[] { "1", "2", "3", "4" };
+
+        assertArrayEquals(expectedArray, quadruple.toArray());
+    }
+    
+    private Quadruple<Object, Object, Object, Object> nullQuadruple() {
+        return new Quadruple<>();
     }
 }

--- a/jtuples/src/test/java/org/jtuples/QuintupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuintupleTest.java
@@ -134,35 +134,35 @@ public class QuintupleTest {
     public void testApplyFirst() {
         result = quintuple.applyFirst(s -> s + s);
 
-        assertEquals(result.first(), "11");
+        assertEquals("11", result.first());
     }
 
     @Test
     public void testApplySecond() {
         result = quintuple.applySecond(s -> s + s);
 
-        assertEquals(result.second(), "22");
+        assertEquals("22", result.second());
     }
 
     @Test
     public void testApplyThird() {
         result = quintuple.applyThird(s -> s + s);
 
-        assertEquals(result.third(), "33");
+        assertEquals("33", result.third());
     }
 
     @Test
     public void testApplyFourth() {
         result = quintuple.applyFourth(s -> s + s);
 
-        assertEquals(result.fourth(), "44");
+        assertEquals("44", result.fourth());
     }
 
     @Test
     public void testApplyFifth() {
         result = quintuple.applyFifth(s -> s + s);
 
-        assertEquals(result.fifth(), "55");
+        assertEquals("55", result.fifth());
     }
 
     @Test
@@ -187,7 +187,7 @@ public class QuintupleTest {
     }
 
     @Test
-    public void testHashCodeIsTheSameForEqualQuintuples() {
+    public void testHashCodeIsTheSameForEqualTuples() {
         Tuple other = new Quintuple<>("1", "2", "3", "4", "5");
         
         assertEquals(other.hashCode(), quintuple.hashCode());

--- a/jtuples/src/test/java/org/jtuples/SextupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/SextupleTest.java
@@ -154,42 +154,42 @@ public class SextupleTest {
     public void testApplyFirst() {
         result = sextuple.applyFirst(s -> s + s);
 
-        assertEquals(result.first(), "11");
+        assertEquals("11", result.first());
     }
 
     @Test
     public void testApplySecond() {
         result = sextuple.applySecond(s -> s + s);
 
-        assertEquals(result.second(), "22");
+        assertEquals("22", result.second());
     }
 
     @Test
     public void testApplyThird() {
         result = sextuple.applyThird(s -> s + s);
 
-        assertEquals(result.third(), "33");
+        assertEquals("33", result.third());
     }
 
     @Test
     public void testApplyFourth() {
         result = sextuple.applyFourth(s -> s + s);
 
-        assertEquals(result.fourth(), "44");
+        assertEquals("44", result.fourth());
     }
 
     @Test
     public void testApplyFifth() {
         result = sextuple.applyFifth(s -> s + s);
 
-        assertEquals(result.fifth(), "55");
+        assertEquals("55", result.fifth());
     }
 
     @Test
     public void testApplySixth() {
         result = sextuple.applySixth(s -> s + s);
 
-        assertEquals(result.sixth(), "66");
+        assertEquals("66", result.sixth());
     }
 
     @Test

--- a/jtuples/src/test/java/org/jtuples/TripleTest.java
+++ b/jtuples/src/test/java/org/jtuples/TripleTest.java
@@ -24,186 +24,144 @@ package org.jtuples;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Before;
 
 /**
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class TripleTest {
+    private Triple<String, String, String> triple;
+    private Triple<String, String, String> expected;
+    private Triple<String, String, String> result;
+    
+    @Before
+    public void setup() {
+        triple = new Triple<>("1", "2", "3");
+    }
 
     @Test
     public void testArity() {
-        Triple<String, String, String> triple = new Triple<>();
-        
-        assertEquals(triple.arity(), 3);
+        assertEquals(3, triple.arity());
     }
 
     @Test
     public void testFirst() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-
-        assertEquals(triple.first(), "hello");
+        assertEquals("1", triple.first());
     }
 
     @Test
     public void testFirstCanBeNull() {
-        Triple<Object, Object, Object> triple = new Triple<>(null, null, null);
-
-        assertNull(triple.first());
+        assertNull(nullTriple().first());
     }
 
     @Test
     public void testSecond() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-
-        assertEquals(triple.second(), "world");
+        assertEquals("2", triple.second());
     }
 
     @Test
     public void testSecondCanBeNull() {
-        Triple<Object, Object, Object> triple = new Triple<>(null, null, null);
-
-        assertNull(triple.second());
+        assertNull(nullTriple().second());
     }
 
     @Test
     public void testThird() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-
-        assertEquals(triple.third(), "!");
+        assertEquals("3", triple.third());
     }
 
     @Test
     public void testThirdCanBeNull() {
-        Triple<Object, Object, Object> triple = new Triple<>(null, null, null);
-
-        assertNull(triple.third());
+        assertNull(nullTriple().third());
     }
 
     @Test
     public void testInvert() {
-        Triple<String, Integer, Boolean> triple =
-                new Triple<>("hello", 123, true);
+        expected = new Triple<>("3", "2", "1");
 
-        Triple<Boolean, Integer, String> other = triple.invert();
-
-        assertEquals(other.first(), true);
-        assertEquals((int)other.second(), 123);
-        assertEquals(other.third(), "hello");
+        assertEquals(expected, triple.invert());
     }
 
     @Test
     public void testApplyFirst() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
+        result = triple.applyFirst(s -> s + s);
 
-        Triple<Integer, String, String> other =
-                triple.applyFirst(s -> s.length());
-
-        assertEquals((int)other.first(), "hello".length());
+        assertEquals("11", result.first());
     }
 
     @Test
     public void testApplySecond() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
+        result = triple.applySecond(s -> s + s);
 
-        Triple<String, Integer, String> other =
-                triple.applySecond(s -> s.length());
-
-        assertEquals((int)other.second(), "world".length());
+        assertEquals("22", result.second());
     }
 
     @Test
     public void testApplyThird() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
+        result = triple.applyThird(s -> s + s);
 
-        Triple<String, String, Integer> other =
-                triple.applyThird(s -> s.length());
-
-        assertEquals((int)other.third(), "!".length());
+        assertEquals("33", result.third());
     }
 
     @Test
     public void testEqualsIsTrueWhenEqual() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, String> other =
-                new Triple<>("hello", "world", "!");
+        Tuple other = new Triple<>("1", "2", "3");
 
         assertTrue(triple.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenNotEqual() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, String> other =
-                new Triple<>("goodbye", "world", "!");
+        Tuple other = new Triple<>("2", "1", "3");
 
         assertFalse(triple.equals(other));
     }
 
     @Test
     public void testEqualsIsFalseWhenTypesAreDifferent() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, Integer> other =
-                new Triple<>("hello", "world", 123);
+        Tuple other = new Triple<>("1", "2", 123);
 
         assertFalse(triple.equals(other));
     }
 
     @Test
-    public void testHashCodeIsTheSameForEqualTriples() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, String> other =
-                new Triple<>("hello", "world", "!");
+    public void testHashCodeIsTheSameForEqualTuples() {
+        Tuple other = new Triple<>("1", "2", "3");
 
-        assertEquals(triple.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void testShiftLeftReturnsNew() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, String> other = triple.shiftLeft();
-
-        assertNotEquals(triple, other);
+        assertEquals(other.hashCode(), triple.hashCode());
     }
 
     @Test
     public void testShiftLeft() {
-        Triple<String, String, String> triple =
-                new Triple<>("1", "2", "3");
-        triple = triple.shiftLeft();
-        Triple<String, String, String> expected =
-                new Triple<>("2", "3", "1");
+        expected = new Triple<>("2", "3", "1");
 
-        assertEquals(triple, expected);
+        assertEquals(expected, triple.shiftLeft());
     }
 
     @Test
-    public void testShiftRightReturnsNew() {
-        Triple<String, String, String> triple =
-                new Triple<>("hello", "world", "!");
-        Triple<String, String, String> other = triple.shiftRight();
-
-        assertNotEquals(triple, other);
+    public void testShiftLeftReturnsNew() {
+        assertNotEquals(triple, triple.shiftLeft());
     }
 
     @Test
     public void testShiftRight() {
-        Triple<String, String, String> triple =
-                new Triple<>("1", "2", "3");
-        triple = triple.shiftRight();
-        Triple<String, String, String> expected =
-                new Triple<>("3", "1", "2");
+        expected = new Triple<>("3", "1", "2");
 
-        assertEquals(triple, expected);
+        assertEquals(expected, triple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightReturnsNew() {
+        assertNotEquals(triple, triple.shiftRight());
+    }
+    
+    @Test
+    public void testToArray() {
+        String[] expectedArray = new String[] { "1", "2", "3" };
+        
+        assertArrayEquals(expectedArray, triple.toArray());
+    }
+    
+    private Triple<Object, Object, Object> nullTriple() {
+        return new Triple<>();
     }
 }


### PR DESCRIPTION
This makes some changes to the tests of all tuples to try to make them more readable and more consistent with each other.

One thing that I fixed is the order of the arguments in most `assert` calls.
The *expected* value is the first argument of all `assert` methods, and it's important for error messages, that are usually like `expected: <expected> but was: <actual>.`