### PR TITLE
Implements the new overloads for the shift methods.

### DIFF
--- a/jtuples/src/main/java/org/jtuples/Pair.java
+++ b/jtuples/src/main/java/org/jtuples/Pair.java
@@ -91,12 +91,22 @@ public final class Pair<A, B> extends AbstractTuple {
 
     @Override
     public Pair<B, A> shiftLeft() {
-        return invert();
+        return shiftLeft(first);
+    }
+
+    @Override
+    public <V> Pair<B, V> shiftLeft(V value) {
+        return new Pair<>(second, value);
     }
 
     @Override
     public Pair<B, A> shiftRight() {
-        return invert();
+        return shiftRight(second);
+    }
+
+    @Override
+    public <V> Pair<V, A> shiftRight(V value) {
+        return new Pair<>(value, first);
     }
 
 

--- a/jtuples/src/main/java/org/jtuples/Quadruple.java
+++ b/jtuples/src/main/java/org/jtuples/Quadruple.java
@@ -114,12 +114,22 @@ public class Quadruple<A, B, C, D> extends AbstractTuple {
 
     @Override
     public Quadruple<B, C, D, A> shiftLeft() {
-        return new Quadruple<>(second, third, fourth, first);
+        return shiftLeft(first);
+    }
+
+    @Override
+    public <V> Quadruple<B, C, D, V> shiftLeft(V value) {
+        return new Quadruple<>(second, third, fourth, value);
     }
 
     @Override
     public Quadruple<D, A, B, C> shiftRight() {
-        return new Quadruple<>(fourth, first, second, third);
+        return shiftRight(fourth);
+    }
+
+    @Override
+    public <V> Quadruple<V, A, B, C> shiftRight(V value) {
+        return new Quadruple<>(value, first, second, third);
     }
 
     

--- a/jtuples/src/main/java/org/jtuples/Quintuple.java
+++ b/jtuples/src/main/java/org/jtuples/Quintuple.java
@@ -126,12 +126,22 @@ public final class Quintuple<A, B, C, D, E> extends AbstractTuple {
 
     @Override
     public Quintuple<B, C, D, E, A> shiftLeft() {
-        return new Quintuple(second(), third(), fourth(), fifth(), first());
+        return shiftLeft(first());
+    }
+
+    @Override
+    public <V> Quintuple<B, C, D, E, V> shiftLeft(V value) {
+        return new Quintuple(second(), third(), fourth(), fifth(), value);
     }
 
     @Override
     public Quintuple<E, A, B, C, D> shiftRight() {
-        return new Quintuple(fifth(), first(), second(), third(), fourth());
+        return shiftRight(fifth());
+    }
+
+    @Override
+    public <V> Quintuple<V, A, B, C, D> shiftRight(V value) {
+        return new Quintuple(value, first(), second(), third(), fourth());
     }
 
     @Override

--- a/jtuples/src/main/java/org/jtuples/Sextuple.java
+++ b/jtuples/src/main/java/org/jtuples/Sextuple.java
@@ -139,13 +139,23 @@ public final class Sextuple<A, B, C, D, E, F> extends AbstractTuple {
 
     @Override
     public Sextuple<B, C, D, E, F, A> shiftLeft() {
+        return shiftLeft(first());
+    }
+
+    @Override
+    public <V> Sextuple<B, C, D, E, F, V> shiftLeft(V value) {
         return new Sextuple<>(second(), third(), fourth(),
-                fifth(), sixth(), first());
+                fifth(), sixth(), value);
     }
 
     @Override
     public Sextuple<F, A, B, C, D, E> shiftRight() {
-        return new Sextuple<>(sixth(), first(), second(),
+        return shiftRight(sixth());
+    }
+
+    @Override
+    public <V> Sextuple<V, A, B, C, D, E> shiftRight(V value) {
+        return new Sextuple<>(value, first(), second(),
                 third(), fourth(), fifth());
     }
 

--- a/jtuples/src/main/java/org/jtuples/Triple.java
+++ b/jtuples/src/main/java/org/jtuples/Triple.java
@@ -102,12 +102,22 @@ public final class Triple<A, B, C> extends AbstractTuple {
 
     @Override
     public Triple<B, C, A> shiftLeft() {
-        return new Triple<>(second, third, first);
+        return shiftLeft(first);
+    }
+
+    @Override
+    public <V> Triple<B, C, V> shiftLeft(V value) {
+        return new Triple<>(second, third, value);
     }
 
     @Override
     public Triple<C, A, B> shiftRight() {
-        return new Triple<>(third, first, second);
+        return shiftRight(third);
+    }
+
+    @Override
+    public <V> Triple<V, A, B> shiftRight(V value) {
+        return new Triple<>(value, first, second);
     }
 
 

--- a/jtuples/src/main/java/org/jtuples/Tuple.java
+++ b/jtuples/src/main/java/org/jtuples/Tuple.java
@@ -48,17 +48,53 @@ public interface Tuple {
 
     /**
      * Returns a new tuple, with the members shifted to the left
-     * by one position.
-     * @return a tuple shifted to the left
+     * by one position. This operation has a wrapping behaviour,
+     * meaning that the member that would be excluded by the shift
+     * instead occupies the new open position.
+     * 
+     * For instance, calling {@code ((1, 2, 3)).shiftLeft()} would yield
+     * the tuple {@code (2, 3, 1)}.
+     * @return a tuple shifted to the left, wrapping around
      */
     Tuple shiftLeft();
 
     /**
+     * Returns a new tuple, with the members shifted to the left
+     * by one position. The given value occupies the new open position,
+     * after shifting the original members.
+     * 
+     * For instance, calling {@code ((1, 2, 3)).shiftLeft(4)} would yield
+     * the tuple {@code (2, 3, 4)}.
+     * @param <V> the type of the new member to be inserted
+     * @param value the new member to be inserted
+     * @return a tuple shifted to the left, with the new member given
+     */
+    <V> Tuple shiftLeft(V value);
+
+    /**
      * Returns a new tuple, with the members shifted to the right
-     * by one position.
-     * @return a tuple shifted to the right
+     * by one position. This operation has a wrapping behaviour,
+     * meaning that the member that would be excluded by the shift
+     * instead occupies the new open position.
+     * 
+     * For instance, calling {@code ((1, 2, 3)).shiftRight()} would yield
+     * the tuple {@code (3, 1, 2)}.
+     * @return a tuple shifted to the right, wrapping around
      */
     Tuple shiftRight();
+
+    /**
+     * Returns a new tuple, with the members shifted to the right
+     * by one position. The given value occupies the new open position,
+     * after shifting the original members.
+     * 
+     * For instance, calling {@code ((1, 2, 3)).shiftRight(0)} would yield
+     * the tuple {@code (0, 1, 2)}.
+     * @param <V> the type of the new member to be inserted
+     * @param value the new member to be inserted
+     * @return a tuple shifted to the right, with the new member given
+     */
+    <V> Tuple shiftRight(V value);
 
     /**
      * Returns a {@code List} view of the elements in this tuple.

--- a/jtuples/src/main/java/org/jtuples/Tuple.java
+++ b/jtuples/src/main/java/org/jtuples/Tuple.java
@@ -22,7 +22,6 @@
 package org.jtuples;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Represents a mathematical tuple.

--- a/jtuples/src/test/java/org/jtuples/FunctionsTest.java
+++ b/jtuples/src/test/java/org/jtuples/FunctionsTest.java
@@ -25,8 +25,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 

--- a/jtuples/src/test/java/org/jtuples/PairTest.java
+++ b/jtuples/src/test/java/org/jtuples/PairTest.java
@@ -154,11 +154,6 @@ public class PairTest {
     }
 
     @Test
-    public void testShiftLeftWithNullReturnsNew() {
-        assertNotEquals(pair, pair.shiftLeft(null));
-    }
-
-    @Test
     public void testShiftRight() {
         expected = new Pair<>("2", "1");
 
@@ -187,11 +182,6 @@ public class PairTest {
         expected = new Pair<>(null, "1");
 
         assertEquals(expected, pair.shiftRight(null));
-    }
-
-    @Test
-    public void testShiftRightWithNullReturnsNew() {
-        assertNotEquals(pair, pair.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/PairTest.java
+++ b/jtuples/src/test/java/org/jtuples/PairTest.java
@@ -115,11 +115,11 @@ public class PairTest {
 
     @Test
     public void testApply() {
-        boolean result = pair.apply((a, b) -> {
+        boolean testResult = pair.apply((a, b) -> {
             return "1".equals(a) && "2".equals(b);
         });
         
-        assertTrue(result);
+        assertTrue(testResult);
     }
 
     @Test
@@ -135,6 +135,30 @@ public class PairTest {
     }
 
     @Test
+    public void testShiftLeftWithValue() {
+        expected = new Pair<>("2", "3");
+
+        assertEquals(expected, pair.shiftLeft("3"));
+    }
+
+    @Test
+    public void testShiftLeftWithValueReturnsNew() {
+        assertNotEquals(pair, pair.shiftLeft("3"));
+    }
+
+    @Test
+    public void testShiftLeftWithNull() {
+        expected = new Pair<>("2", null);
+
+        assertEquals(expected, pair.shiftLeft(null));
+    }
+
+    @Test
+    public void testShiftLeftWithNullReturnsNew() {
+        assertNotEquals(pair, pair.shiftLeft(null));
+    }
+
+    @Test
     public void testShiftRight() {
         expected = new Pair<>("2", "1");
 
@@ -144,6 +168,30 @@ public class PairTest {
     @Test
     public void testShiftRightReturnsNew() {
         assertNotEquals(pair, pair.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightWithValue() {
+        expected = new Pair<>("0", "1");
+
+        assertEquals(expected, pair.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithValueReturnsNew() {
+        assertNotEquals(pair, pair.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithNull() {
+        expected = new Pair<>(null, "1");
+
+        assertEquals(expected, pair.shiftRight(null));
+    }
+
+    @Test
+    public void testShiftRightWithNullReturnsNew() {
+        assertNotEquals(pair, pair.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
@@ -179,11 +179,6 @@ public class QuadrupleTest {
     }
 
     @Test
-    public void testShiftLeftWithNullReturnsNew() {
-        assertNotEquals(quadruple, quadruple.shiftLeft(null));
-    }
-
-    @Test
     public void testShiftRight() {
         expected = new Quadruple<>("4", "1", "2", "3");
 
@@ -212,11 +207,6 @@ public class QuadrupleTest {
         expected = new Quadruple<>(null, "1", "2", "3");
 
         assertEquals(expected, quadruple.shiftRight(null));
-    }
-
-    @Test
-    public void testShiftRightWithNullReturnsNew() {
-        assertNotEquals(quadruple, quadruple.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
@@ -160,6 +160,30 @@ public class QuadrupleTest {
     }
 
     @Test
+    public void testShiftLeftWithValue() {
+        expected = new Quadruple<>("2", "3", "4", "5");
+
+        assertEquals(expected, quadruple.shiftLeft("5"));
+    }
+
+    @Test
+    public void testShiftLeftWithValueReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftLeft("5"));
+    }
+
+    @Test
+    public void testShiftLeftWithNull() {
+        expected = new Quadruple<>("2", "3", "4", null);
+
+        assertEquals(expected, quadruple.shiftLeft(null));
+    }
+
+    @Test
+    public void testShiftLeftWithNullReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftLeft(null));
+    }
+
+    @Test
     public void testShiftRight() {
         expected = new Quadruple<>("4", "1", "2", "3");
 
@@ -169,6 +193,30 @@ public class QuadrupleTest {
     @Test
     public void testShiftRightReturnsNew() {
         assertNotEquals(quadruple, quadruple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightWithValue() {
+        expected = new Quadruple<>("0", "1", "2", "3");
+
+        assertEquals(expected, quadruple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithValueReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithNull() {
+        expected = new Quadruple<>(null, "1", "2", "3");
+
+        assertEquals(expected, quadruple.shiftRight(null));
+    }
+
+    @Test
+    public void testShiftRightWithNullReturnsNew() {
+        assertNotEquals(quadruple, quadruple.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/QuintupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuintupleTest.java
@@ -137,11 +137,6 @@ public class QuintupleTest {
     }
 
     @Test
-    public void testShiftLeftWithNullReturnsNew() {
-        assertNotEquals(quintuple, quintuple.shiftLeft(null));
-    }
-
-    @Test
     public void testShiftRight() {
         expected = new Quintuple<>("5", "1", "2", "3", "4");
         
@@ -172,11 +167,6 @@ public class QuintupleTest {
         expected = new Quintuple<>(null, "1", "2", "3", "4");
 
         assertEquals(expected, quintuple.shiftRight(null));
-    }
-
-    @Test
-    public void testShiftRightWithNullReturnsNew() {
-        assertNotEquals(quintuple, quintuple.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/QuintupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuintupleTest.java
@@ -113,12 +113,70 @@ public class QuintupleTest {
     }
 
     @Test
+    public void testShiftLeftReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftLeft());
+    }
+
+    @Test
+    public void testShiftLeftWithValue() {
+        expected = new Quintuple<>("2", "3", "4", "5", "6");
+
+        assertEquals(expected, quintuple.shiftLeft("6"));
+    }
+
+    @Test
+    public void testShiftLeftWithValueReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftLeft("6"));
+    }
+
+    @Test
+    public void testShiftLeftWithNull() {
+        expected = new Quintuple<>("2", "3", "4", "5", null);
+
+        assertEquals(expected, quintuple.shiftLeft(null));
+    }
+
+    @Test
+    public void testShiftLeftWithNullReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftLeft(null));
+    }
+
+    @Test
     public void testShiftRight() {
         expected = new Quintuple<>("5", "1", "2", "3", "4");
         
         result = quintuple.shiftRight();
         
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShiftRightReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightWithValue() {
+        expected = new Quintuple<>("0", "1", "2", "3", "4");
+
+        assertEquals(expected, quintuple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithValueReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithNull() {
+        expected = new Quintuple<>(null, "1", "2", "3", "4");
+
+        assertEquals(expected, quintuple.shiftRight(null));
+    }
+
+    @Test
+    public void testShiftRightWithNullReturnsNew() {
+        assertNotEquals(quintuple, quintuple.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/SextupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/SextupleTest.java
@@ -147,11 +147,6 @@ public class SextupleTest {
     }
 
     @Test
-    public void testShiftLeftWithNullReturnsNew() {
-        assertNotEquals(sextuple, sextuple.shiftLeft(null));
-    }
-
-    @Test
     public void testShiftRight() {
         expected = new Sextuple<>("6", "1", "2", "3", "4", "5");
         
@@ -182,11 +177,6 @@ public class SextupleTest {
         expected = new Sextuple<>(null, "1", "2", "3", "4", "5");
 
         assertEquals(expected, sextuple.shiftRight(null));
-    }
-
-    @Test
-    public void testShiftRightWithNullReturnsNew() {
-        assertNotEquals(sextuple, sextuple.shiftRight(null));
     }
 
     @Test

--- a/jtuples/src/test/java/org/jtuples/SextupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/SextupleTest.java
@@ -128,6 +128,30 @@ public class SextupleTest {
     }
 
     @Test
+    public void testShiftLeftWithValue() {
+        expected = new Sextuple<>("2", "3", "4", "5", "6", "7");
+
+        assertEquals(expected, sextuple.shiftLeft("7"));
+    }
+
+    @Test
+    public void testShiftLeftWithValueReturnsNew() {
+        assertNotEquals(sextuple, sextuple.shiftLeft("3"));
+    }
+
+    @Test
+    public void testShiftLeftWithNull() {
+        expected = new Sextuple<>("2", "3", "4", "5", "6", null);
+
+        assertEquals(expected, sextuple.shiftLeft(null));
+    }
+
+    @Test
+    public void testShiftLeftWithNullReturnsNew() {
+        assertNotEquals(sextuple, sextuple.shiftLeft(null));
+    }
+
+    @Test
     public void testShiftRight() {
         expected = new Sextuple<>("6", "1", "2", "3", "4", "5");
         
@@ -139,6 +163,30 @@ public class SextupleTest {
     @Test
     public void testShiftRightReturnsNew() {
         assertNotEquals(sextuple, sextuple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightWithValue() {
+        expected = new Sextuple<>("0", "1", "2", "3", "4", "5");
+
+        assertEquals(expected, sextuple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithValueReturnsNew() {
+        assertNotEquals(sextuple, sextuple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithNull() {
+        expected = new Sextuple<>(null, "1", "2", "3", "4", "5");
+
+        assertEquals(expected, sextuple.shiftRight(null));
+    }
+
+    @Test
+    public void testShiftRightWithNullReturnsNew() {
+        assertNotEquals(sextuple, sextuple.shiftRight(null));
     }
 
     @Test

--- a/jtuples/src/test/java/org/jtuples/TripleTest.java
+++ b/jtuples/src/test/java/org/jtuples/TripleTest.java
@@ -157,11 +157,6 @@ public class TripleTest {
     }
 
     @Test
-    public void testShiftLeftWithNullReturnsNew() {
-        assertNotEquals(triple, triple.shiftLeft(null));
-    }
-
-    @Test
     public void testShiftLeftReturnsNew() {
         assertNotEquals(triple, triple.shiftLeft());
     }
@@ -195,11 +190,6 @@ public class TripleTest {
         expected = new Triple<>(null, "1", "2");
 
         assertEquals(expected, triple.shiftRight(null));
-    }
-
-    @Test
-    public void testShiftRightWithNullReturnsNew() {
-        assertNotEquals(triple, triple.shiftRight(null));
     }
     
     @Test

--- a/jtuples/src/test/java/org/jtuples/TripleTest.java
+++ b/jtuples/src/test/java/org/jtuples/TripleTest.java
@@ -138,6 +138,30 @@ public class TripleTest {
     }
 
     @Test
+    public void testShiftLeftWithValue() {
+        expected = new Triple<>("2", "3", "4");
+
+        assertEquals(expected, triple.shiftLeft("4"));
+    }
+
+    @Test
+    public void testShiftLeftWithValueReturnsNew() {
+        assertNotEquals(triple, triple.shiftLeft("4"));
+    }
+
+    @Test
+    public void testShiftLeftWithNull() {
+        expected = new Triple<>("2", "3", null);
+
+        assertEquals(expected, triple.shiftLeft(null));
+    }
+
+    @Test
+    public void testShiftLeftWithNullReturnsNew() {
+        assertNotEquals(triple, triple.shiftLeft(null));
+    }
+
+    @Test
     public void testShiftLeftReturnsNew() {
         assertNotEquals(triple, triple.shiftLeft());
     }
@@ -152,6 +176,30 @@ public class TripleTest {
     @Test
     public void testShiftRightReturnsNew() {
         assertNotEquals(triple, triple.shiftRight());
+    }
+
+    @Test
+    public void testShiftRightWithValue() {
+        expected = new Triple<>("0", "1", "2");
+
+        assertEquals(expected, triple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithValueReturnsNew() {
+        assertNotEquals(triple, triple.shiftRight("0"));
+    }
+
+    @Test
+    public void testShiftRightWithNull() {
+        expected = new Triple<>(null, "1", "2");
+
+        assertEquals(expected, triple.shiftRight(null));
+    }
+
+    @Test
+    public void testShiftRightWithNullReturnsNew() {
+        assertNotEquals(triple, triple.shiftRight(null));
     }
     
     @Test


### PR DESCRIPTION
I added the new overloads we discussed for `shiftLeft` and `shiftRight` methods, along with tests to cover them. I also took the liberty to remove some unused imports, to reduce the amount of warnings to a minimum.