### PR TITLE
Add Travis badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Java gets a pair.
 
+[![Build][travis-badge]][travis]
+[travis]: https://travis-ci.org/git-afsantos/jTuples
+[travis-badge]: https://api.travis-ci.org/git-afsantos/jTuples.svg
+
 The **jTuples** project provides [tuple](http://en.wikipedia.org/wiki/Tuple) implementations for the Java platform.
 
 Requires JDK 8 or higher.


### PR DESCRIPTION
Since we're now using Travis to run our tests, we can add a badge to the readme that shows if the result of the last build.