### PR TITLE
Remove emails from author tags

### DIFF
--- a/jtuples/src/main/java/org/jtuples/AbstractTuple.java
+++ b/jtuples/src/main/java/org/jtuples/AbstractTuple.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
 /**
  * This class provides skeletal implementations of common methods for tuples.
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Andre Santos
+ * @author Benjamim Sonntag
  */
 public abstract class AbstractTuple implements Tuple {
     /**

--- a/jtuples/src/main/java/org/jtuples/Decuple.java
+++ b/jtuples/src/main/java/org/jtuples/Decuple.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * the ordered decuple {@code (b, a, c, d, e, f, g, h, i, j)} unless
  * {@code a} and {@code b} are equal.
  * 
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the decuple
  * @param <B> the type of the second element of the decuple
  * @param <C> the type of the third element of the decuple

--- a/jtuples/src/main/java/org/jtuples/Functions.java
+++ b/jtuples/src/main/java/org/jtuples/Functions.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  * This class provides static methods to support a functional programming style.
  * It provides methods commonly seen in functional programming environments,
  * that revolve around the use of tuples and functions (or lambdas).
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public final class Functions {
     private Functions() {

--- a/jtuples/src/main/java/org/jtuples/Nonuple.java
+++ b/jtuples/src/main/java/org/jtuples/Nonuple.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * ordered nonuple {@code (b, a, c, d, e, f, g, h, i)} unless
  * {@code a} and {@code b} are equal.
  * 
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the nonuple
  * @param <B> the type of the second element of the nonuple
  * @param <C> the type of the third element of the nonuple

--- a/jtuples/src/main/java/org/jtuples/Octuple.java
+++ b/jtuples/src/main/java/org/jtuples/Octuple.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * ordered octuple {@code (b, a, c, d, e, f, g, h)} unless
  * {@code a} and {@code b} are equal.
  * 
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the octuple
  * @param <B> the type of the second element of the octuple
  * @param <C> the type of the third element of the octuple

--- a/jtuples/src/main/java/org/jtuples/Pair.java
+++ b/jtuples/src/main/java/org/jtuples/Pair.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * the ordered pair {@code (a, b)} is different from the ordered pair
  * {@code (b, a)} unless {@code a} and {@code b} are equal.
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the pair
  * @param <B> the type of the second element of the pair
  */

--- a/jtuples/src/main/java/org/jtuples/Quadruple.java
+++ b/jtuples/src/main/java/org/jtuples/Quadruple.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * the ordered quadruple {@code (a, b, c, d)} is different from the ordered
  * quadruple {@code (b, a, c, d)} unless {@code a} and {@code b} are equal.
  * 
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  * @param <A> the type of the first element of the quadruple
  * @param <B> the type of the second element of the quadruple
  * @param <C> the type of the third element of the quadruple

--- a/jtuples/src/main/java/org/jtuples/Quintuple.java
+++ b/jtuples/src/main/java/org/jtuples/Quintuple.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * the ordered quintuple {@code (a, b, c, d, e)} is different from the ordered
  * quintuple {@code (b, a, c, d, e)} unless {@code a} and {@code b} are equal.
  * 
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  * @param <A> the type of the first element of the quintuple
  * @param <B> the type of the second element of the quintuple
  * @param <C> the type of the third element of the quintuple

--- a/jtuples/src/main/java/org/jtuples/Septuple.java
+++ b/jtuples/src/main/java/org/jtuples/Septuple.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * ordered septuple {@code (b, a, c, d, e, f, g)} unless
  * {@code a} and {@code b} are equal.
  * 
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the septuple
  * @param <B> the type of the second element of the septuple
  * @param <C> the type of the third element of the septuple

--- a/jtuples/src/main/java/org/jtuples/Sextuple.java
+++ b/jtuples/src/main/java/org/jtuples/Sextuple.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * the ordered sextuple {@code (a, b, c, d, e, f)} is different from the ordered
  * sextuple {@code (b, a, c, d, e, f)} unless {@code a} and {@code b} are equal.
  * 
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  * @param <A> the type of the first element of the sextuple
  * @param <B> the type of the second element of the sextuple
  * @param <C> the type of the third element of the sextuple

--- a/jtuples/src/main/java/org/jtuples/Triple.java
+++ b/jtuples/src/main/java/org/jtuples/Triple.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * the ordered triple {@code (a, b, c)} is different from the ordered triple
  * {@code (b, a, c)} unless {@code a} and {@code b} are equal.
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  * @param <A> the type of the first element of the triple
  * @param <B> the type of the second element of the triple
  * @param <C> the type of the third element of the triple

--- a/jtuples/src/main/java/org/jtuples/Tuple.java
+++ b/jtuples/src/main/java/org/jtuples/Tuple.java
@@ -29,7 +29,7 @@ import java.util.List;
  * The number and type of its members are determined by the implementing
  * classes.
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public interface Tuple {
     /**

--- a/jtuples/src/main/java/org/jtuples/Tuples.java
+++ b/jtuples/src/main/java/org/jtuples/Tuples.java
@@ -38,8 +38,8 @@ import java.util.function.Function;
  * <li>{@code zip}
  * </ul>
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Andre Santos
+ * @author Benjamim Sonntag
  * @see org.jtuples.Tuple
  */
 public final class Tuples {

--- a/jtuples/src/test/java/org/jtuples/DecupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/DecupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public class DecupleTest {
     private Decuple<String, String, String, String,

--- a/jtuples/src/test/java/org/jtuples/FunctionsTest.java
+++ b/jtuples/src/test/java/org/jtuples/FunctionsTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public class FunctionsTest {
     

--- a/jtuples/src/test/java/org/jtuples/NonupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/NonupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public class NonupleTest {
     private Nonuple<String, String, String, String,

--- a/jtuples/src/test/java/org/jtuples/OctupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/OctupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public class OctupleTest {
     private Octuple<String, String, String, String,

--- a/jtuples/src/test/java/org/jtuples/PairTest.java
+++ b/jtuples/src/test/java/org/jtuples/PairTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 
 /**
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  */
 public class PairTest {
     private Pair<String, String> pair;

--- a/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuadrupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 
 /**
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  */
 public class QuadrupleTest {
     private Quadruple<String, String, String, String> quadruple;

--- a/jtuples/src/test/java/org/jtuples/QuintupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/QuintupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  */
 public class QuintupleTest {
     private Quintuple<String, String, String, String, String> quintuple;

--- a/jtuples/src/test/java/org/jtuples/SeptupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/SeptupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
+ * @author Andre Santos
  */
 public class SeptupleTest {
     private Septuple<String, String, String, String,

--- a/jtuples/src/test/java/org/jtuples/SextupleTest.java
+++ b/jtuples/src/test/java/org/jtuples/SextupleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  */
 public class SextupleTest {
     private Sextuple<String, String, String, String, String, String> sextuple;

--- a/jtuples/src/test/java/org/jtuples/TripleTest.java
+++ b/jtuples/src/test/java/org/jtuples/TripleTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 
 /**
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Benjamim Sonntag
  */
 public class TripleTest {
     private Triple<String, String, String> triple;

--- a/jtuples/src/test/java/org/jtuples/TuplesTest.java
+++ b/jtuples/src/test/java/org/jtuples/TuplesTest.java
@@ -29,8 +29,8 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Andre Santos <contact.andre.santos@gmail.com>
- * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @author Andre Santos
+ * @author Benjamim Sonntag
  */
 public class TuplesTest {
 


### PR DESCRIPTION
Turns out we can't use `<` and `>` in javadocs. Besides, the emails don't look good in the generated docs anyway.